### PR TITLE
fixed prod refresh

### DIFF
--- a/frontend/logs/temp_workflow.txt
+++ b/frontend/logs/temp_workflow.txt
@@ -1,11 +1,11 @@
 === Workflow Run Started ===
-Job ID: 06744dbd-246a-4f83-bf9a-b64ee055c63c
-Started: 2025-09-27T04:24:59.172Z
+Job ID: e68094c2-1efb-4cb5-a97e-6313c98e2edc
+Started: 2025-09-30T02:03:08.817Z
 ==================================================
 
 [INFO] Workflow started - Provider: gemini, Model: gemini-2.5-flash-lite, Personality: career_savvy_colleague
 
 ==================================================
 === Workflow Run Completed ===
-Job ID: 06744dbd-246a-4f83-bf9a-b64ee055c63c
-Completed: 2025-09-27T04:24:59.181Z
+Job ID: e68094c2-1efb-4cb5-a97e-6313c98e2edc
+Completed: 2025-09-30T02:03:08.823Z

--- a/frontend/server/routes/recompile.js
+++ b/frontend/server/routes/recompile.js
@@ -23,6 +23,9 @@ router.post('/:jobId/:fileType', async (req, res) => {
       return res.status(400).json({ message: 'Invalid file type' })
     }
     
+    // Use consistent temp directory path that matches the project structure
+    // In production: /app/frontend/temp/{jobId}
+    // In development: {project_root}/frontend/temp/{jobId}
     const tempDir = path.join(__dirname, '../../temp', jobId)
     
     // Check if job directory exists
@@ -61,13 +64,26 @@ router.post('/:jobId/:fileType', async (req, res) => {
     const pythonScriptPath = process.env.NODE_ENV === 'production' ? 'python' : path.join(__dirname, '../../../venv/bin/python3')
     const workingDir = path.join(__dirname, '../../..')
     
+    // Use absolute path for temp directory to avoid path resolution issues
+    const tempDirAbsolute = path.resolve(__dirname, '../../temp')
+    
+    // Debug logging for production troubleshooting
+    console.log('Recompile debug info:', {
+      jobId,
+      fileType,
+      tempDir: tempDirAbsolute,
+      workingDir,
+      pythonScriptPath,
+      nodeEnv: process.env.NODE_ENV
+    })
+    
     const args = [
       '-m', 'tex_tailor.cli',
       'recompile',
       '--job-id', jobId,
       '--file-type', fileType,
       '--content', content,
-      '--temp-dir', path.join(__dirname, '../../temp')
+      '--temp-dir', tempDirAbsolute
     ]
     
     // Execute recompile command
@@ -88,6 +104,10 @@ router.post('/:jobId/:fileType', async (req, res) => {
     })
 
     childProcess.on('close', async (code) => {
+      console.log(`Python process exited with code: ${code}`)
+      console.log('STDOUT:', stdout)
+      console.log('STDERR:', stderr)
+      
       if (code === 0) {
         console.log('Recompilation successful:', stdout)
         
@@ -121,7 +141,13 @@ router.post('/:jobId/:fileType', async (req, res) => {
           res.status(500).json({
             success: false,
             message: 'PDF file not found after compilation',
-            error: verifyError.message
+            error: verifyError.message,
+            debug: {
+              expectedFile,
+              tempDir,
+              stdout,
+              stderr
+            }
           })
         }
       } else {
@@ -129,7 +155,15 @@ router.post('/:jobId/:fileType', async (req, res) => {
         res.status(500).json({
           success: false,
           message: 'LaTeX compilation failed',
-          error: stderr
+          error: stderr,
+          debug: {
+            exitCode: code,
+            stdout,
+            stderr,
+            tempDir,
+            workingDir,
+            pythonScriptPath
+          }
         })
       }
     })

--- a/frontend/server/routes/review.js
+++ b/frontend/server/routes/review.js
@@ -14,8 +14,8 @@ router.get('/', async (req, res) => {
     const { format = 'json', provider } = req.query
     
     // Execute the Python CLI review command
-    // Use full path to Python since Node.js may not find it in PATH
-    const pythonCmd = '/opt/homebrew/opt/python@3.13/bin/python3.13'
+    // In Docker production, Python is in PATH due to ENV PATH="/opt/venv/bin:$PATH"
+    const pythonCmd = process.env.NODE_ENV === 'production' ? 'python' : '/opt/homebrew/opt/python@3.13/bin/python3.13'
     
     const args = ['-m', 'tex_tailor.cli', 'review', '--format', format]
     if (provider) {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Stabilizes LaTeX recompile by using an absolute temp dir with extensive debug/error details and switches review route to use python from PATH in production.
> 
> - **Server (Node/Express)**:
>   - **Recompile (`frontend/server/routes/recompile.js`)**:
>     - Use absolute `temp` directory path and pass it to Python CLI (`--temp-dir`).
>     - Add detailed debug logging (jobId, fileType, paths, env) and process output on completion.
>     - Enrich error responses with diagnostics (exitCode, stdout, stderr, paths; include expected file on verify failure).
>   - **Review (`frontend/server/routes/review.js`)**:
>     - Use `python` from PATH in production; keep explicit Homebrew path in development.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1f3d6ffc9b86dee4d037391fdbca609dd6d8adbb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->